### PR TITLE
feat: add quote-and-confirm endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,18 @@ git checkout v1.0
 
 For more **advanced** usage, you can use the [Global Storage](./docs/global_store.md)
 
-<img src="./assets/8.png" width="800">    
+<img src="./assets/8.png" width="800">
+
+## Quote then Run
+
+This fork adds two endpoints that let you preview token usage and cost before running an LLM call:
+
+- `POST /quote` – estimate tokens and price; returns a `quote_id`.
+- `POST /confirm` – run the quoted request only after approval.
+
+Quotes are stored in a KV namespace for 15 minutes. Pricing is configured via the `PRICING_JSON` variable.
+
+### Streamlit helper
+
+`streamlit_app.py` provides a minimal UI where you can duplicate prompt blocks to run multiple quotes in parallel.
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -5,4 +5,7 @@ export type Bindings = {
   TOOL_NAME: string;
   TOOL_DESCRIPTION: string;
   DB: D1Database;
+  OPENAI_API_KEY: string;
+  PRICING_JSON: string;
+  QUOTES_KV: KVNamespace;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { bearerAuth } from "hono/bearer-auth";
 import { Bindings } from "./bindings";
 import { swaggerUI } from "@hono/swagger-ui";
 import { getUser, createUser, updateUser } from "./users";
+import { quote, confirm } from "./llm";
 
 const app = new OpenAPIHono<{ Bindings: Bindings }>();
 
@@ -106,6 +107,98 @@ app
         error: "Internal Server Error",
       });
     }
+  })
+  .openapi(quote, async (c) => {
+    const {
+      provider,
+      model,
+      system = "",
+      prompt,
+      max_output_tokens = 512,
+      expected_output_tokens = 400,
+    } = c.req.valid("json");
+
+    const pricing = JSON.parse(c.env.PRICING_JSON as string) as Record<string, { in: number; out: number }>;
+    const key = `${provider}:${model}`;
+    const p = pricing[key];
+    if (!p) {
+      return c.json({ error: `Pricing not configured for ${key}` }, 400);
+    }
+
+    const inputTokens = Math.ceil((system + "\n" + prompt).length / 4);
+    const estOut = Math.min(expected_output_tokens, max_output_tokens);
+    const estCost = (inputTokens * p.in + estOut * p.out) / 1000;
+
+    const id = crypto.randomUUID();
+    const quoteData = {
+      id,
+      provider,
+      model,
+      system,
+      prompt,
+      inputTokens,
+      estOut,
+      estCost,
+      caps: { max_output_tokens, max_cost_usd: 1.0 },
+    };
+    await c.env.QUOTES_KV.put(`q:${id}`, JSON.stringify(quoteData), { expirationTtl: 900 });
+
+    return c.json({
+      quote_id: id,
+      input_tokens: inputTokens,
+      estimated_output_tokens: estOut,
+      price_per_1k: { input: p.in, output: p.out },
+      estimated_cost_usd: Math.round(estCost * 100) / 100,
+      caps: quoteData.caps,
+      expires_in_seconds: 900,
+    });
+  })
+  .openapi(confirm, async (c) => {
+    const { quote_id, accept } = c.req.valid("json");
+    if (!accept) {
+      return c.json({ error: "Not accepted" }, 400);
+    }
+
+    const raw = await c.env.QUOTES_KV.get(`q:${quote_id}`);
+    if (!raw) {
+      return c.json({ error: "Quote expired or not found" }, 404);
+    }
+    const q = JSON.parse(raw);
+
+    const pricing = JSON.parse(c.env.PRICING_JSON as string) as Record<string, { in: number; out: number }>;
+    const p = pricing[`${q.provider}:${q.model}`];
+
+    const r = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${c.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: q.model,
+        messages: [
+          ...(q.system ? [{ role: "system", content: q.system }] : []),
+          { role: "user", content: q.prompt },
+        ],
+        max_tokens: q.caps.max_output_tokens,
+      }),
+    });
+    const j = await r.json();
+    const answer = j.choices?.[0]?.message?.content ?? "";
+    const usage = {
+      input_tokens: j.usage?.prompt_tokens ?? q.inputTokens,
+      output_tokens: j.usage?.completion_tokens ?? 0,
+    };
+    const cost = (usage.input_tokens * p.in + usage.output_tokens * p.out) / 1000;
+
+    return c.json({
+      run_id: crypto.randomUUID(),
+      answer,
+      usage,
+      actual_cost_usd: Math.round(cost * 100) / 100,
+      model: q.model,
+      provider: q.provider,
+    });
   });
 
 app.openAPIRegistry.registerComponent("securitySchemes", "Bearer", {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1,0 +1,84 @@
+import { createRoute } from "@hono/zod-openapi";
+import { z } from "@hono/zod-openapi";
+
+const QuoteBodySchema = z.object({
+  provider: z.string().openapi({ example: "openai" }),
+  model: z.string().openapi({ example: "gpt-4.1-mini" }),
+  system: z.string().optional().openapi({ example: "You are a helpful assistant" }),
+  prompt: z.string().openapi({ example: "Explain Romans 8:28" }),
+  max_output_tokens: z.number().optional().default(512).openapi({ example: 512 }),
+  expected_output_tokens: z.number().optional().default(400).openapi({ example: 400 }),
+});
+
+const QuoteResponseSchema = z.object({
+  quote_id: z.string(),
+  input_tokens: z.number(),
+  estimated_output_tokens: z.number(),
+  price_per_1k: z.object({ input: z.number(), output: z.number() }),
+  estimated_cost_usd: z.number(),
+  caps: z.object({
+    max_cost_usd: z.number(),
+    max_output_tokens: z.number(),
+  }),
+  expires_in_seconds: z.number(),
+});
+
+export const quote = createRoute({
+  method: "post",
+  path: "/quote",
+  operationId: "quote",
+  summary: "Estimate token usage & cost",
+  security: [
+    { Bearer: [] },
+  ],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: QuoteBodySchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: QuoteResponseSchema } },
+      description: "Quote",
+    },
+  },
+});
+
+const ConfirmBodySchema = z.object({
+  quote_id: z.string(),
+  accept: z.boolean(),
+});
+
+const ConfirmResponseSchema = z.object({
+  run_id: z.string(),
+  answer: z.string(),
+  usage: z.object({ input_tokens: z.number(), output_tokens: z.number() }),
+  actual_cost_usd: z.number(),
+  model: z.string(),
+  provider: z.string(),
+});
+
+export const confirm = createRoute({
+  method: "post",
+  path: "/confirm",
+  operationId: "confirm",
+  summary: "Run previously quoted request after approval",
+  security: [
+    { Bearer: [] },
+  ],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: ConfirmBodySchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: ConfirmResponseSchema } },
+      description: "Result",
+    },
+  },
+});

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,46 @@
+import streamlit as st
+import requests
+
+API_BASE = st.secrets.get("WORKER_URL", "http://localhost:8787")
+TOKEN = st.secrets.get("TOKEN", "bananaiscool")
+
+if "queries" not in st.session_state:
+    st.session_state.queries = [""]
+
+st.title("Quote then Run")
+
+if st.button("Add Query"):
+    st.session_state.queries.append("")
+
+for i, _ in enumerate(st.session_state.queries):
+    st.subheader(f"Query {i+1}")
+    prompt_key = f"prompt_{i}"
+    st.session_state.queries[i] = st.text_area("Prompt", st.session_state.queries[i], key=prompt_key)
+
+    if st.button("Get Quote", key=f"quote_{i}"):
+        r = requests.post(
+            f"{API_BASE}/quote",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+            json={
+                "provider": "openai",
+                "model": "gpt-4.1-mini",
+                "prompt": st.session_state.queries[i],
+            },
+        )
+        st.session_state[f"quote_{i}"] = r.json()
+
+    q = st.session_state.get(f"quote_{i}")
+    if q:
+        st.json(q)
+        if st.button("Confirm & Run", key=f"confirm_{i}"):
+            r = requests.post(
+                f"{API_BASE}/confirm",
+                headers={"Authorization": f"Bearer {TOKEN}"},
+                json={"quote_id": q.get("quote_id"), "accept": True},
+            )
+            st.session_state[f"resp_{i}"] = r.json()
+
+    resp = st.session_state.get(f"resp_{i}")
+    if resp:
+        st.write(resp.get("answer", ""))
+        st.caption(f"Cost: ${resp.get('actual_cost_usd', 0)}")

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -7,10 +7,11 @@ OPENAPI_VERSION = "3.1.0"
 TOOL_VERSION = "1.0.0"
 TOOL_NAME = "Dify Custom Tool"
 TOOL_DESCRIPTION = "Dify Custom Tool"
+PRICING_JSON = '{"openai:gpt-4.1-mini":{"in":0.15,"out":0.60}}'
 
-# [[kv_namespaces]]
-# binding = "MY_KV_NAMESPACE"
-# id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+[[kv_namespaces]]
+binding = "QUOTES_KV"
+id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # [[r2_buckets]]
 # binding = "MY_BUCKET"
 # bucket_name = "my-bucket"


### PR DESCRIPTION
## Summary
- add `/quote` and `/confirm` endpoints with pricing estimates
- store pending quotes in KV and run LLM after approval
- include simple Streamlit app for duplicating queries

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b8a1c389f48331947d6c43501b3cfe